### PR TITLE
Implement complete option for use with multiProof

### DIFF
--- a/src/MerkleTree.ts
+++ b/src/MerkleTree.ts
@@ -21,7 +21,7 @@ export interface Options {
   hashLeaves?: boolean
   /** If set to `true`, constructs the Merkle Tree using the [Bitcoin Merkle Tree implementation](http://www.righto.com/2014/02/bitcoin-mining-hard-way-algorithms.html). Enable it when you need to replicate Bitcoin constructed Merkle Trees. In Bitcoin Merkle Trees, single nodes are combined with themselves, and each output hash is hashed again. */
   isBitcoinTree?: boolean
-  /** If set to `true`, the leaves will be sorted. */
+  /** If set to `true`, the leaves will be sorted. Recommended for use of multiProofs. */
   sortLeaves?: boolean
   /** If set to `true`, the hashing pairs will be sorted. */
   sortPairs?: boolean

--- a/src/MerkleTree.ts
+++ b/src/MerkleTree.ts
@@ -906,12 +906,12 @@ export class MerkleTree extends Base {
       throw new Error('Invalid Inputs!')
     }
 
+    let ids : number[]
     if (leaves.every(Number.isInteger)) {
-      leaves = leaves
+      ids = leaves.sort((a, b) => a === b ? 0 : a > b ? 1 : -1) // Indices where passed
     } else {
-      leaves = leaves.map((el) => this._bufferIndexOf(this.leaves, el))
+      ids = leaves.map((el) => this._bufferIndexOf(this.leaves, el)).sort((a, b) => a === b ? 0 : a > b ? 1 : -1)
     }
-    let ids : number[] = [...leaves].sort((a, b) => a === b ? 0 : a > b ? 1 : -1)
 
     if (!ids.every((idx: number) => idx !== -1)) {
       throw new Error('Element does not exist in Merkle tree')
@@ -935,11 +935,6 @@ export class MerkleTree extends Base {
         ids.push((idx / 2) | 0)
         return ids
       }, [])
-    }
-
-    const leafValues = leaves.map(i => this.leaves[i]);
-    if (!this.verifyMultiProofWithFlags(this.getRoot(), leafValues, proofs, flags)) {
-      throw new Error('cannot generate multiProof flags for parameters')
     }
 
     return flags

--- a/src/MerkleTree.ts
+++ b/src/MerkleTree.ts
@@ -908,7 +908,7 @@ export class MerkleTree extends Base {
 
     let ids : number[]
     if (leaves.every(Number.isInteger)) {
-      ids = leaves.sort((a, b) => a === b ? 0 : a > b ? 1 : -1) // Indices where passed
+      ids = [...leaves].sort((a, b) => a === b ? 0 : a > b ? 1 : -1) // Indices where passed
     } else {
       ids = leaves.map((el) => this._bufferIndexOf(this.leaves, el)).sort((a, b) => a === b ? 0 : a > b ? 1 : -1)
     }

--- a/src/MerkleTree.ts
+++ b/src/MerkleTree.ts
@@ -766,7 +766,7 @@ export class MerkleTree extends Base {
    */
   getMultiProof (tree?: any[], indices?: any[]):Buffer[] {
     if (!this.complete) {
-      console.warn('for correct use of multiProof it\'s strongly recommended to set complete: true')
+      console.warn('Warning: For correct multiProofs it\'s strongly recommended to set complete: true')
     }
 
     if (!indices) {
@@ -906,12 +906,12 @@ export class MerkleTree extends Base {
       throw new Error('Invalid Inputs!')
     }
 
-    let ids : number[]
     if (leaves.every(Number.isInteger)) {
-      ids = leaves.sort((a, b) => a === b ? 0 : a > b ? 1 : -1) // Indices where passed
+      leaves = leaves
     } else {
-      ids = leaves.map((el) => this._bufferIndexOf(this.leaves, el)).sort((a, b) => a === b ? 0 : a > b ? 1 : -1)
+      leaves = leaves.map((el) => this._bufferIndexOf(this.leaves, el))
     }
+    let ids : number[] = [...leaves].sort((a, b) => a === b ? 0 : a > b ? 1 : -1)
 
     if (!ids.every((idx: number) => idx !== -1)) {
       throw new Error('Element does not exist in Merkle tree')
@@ -935,6 +935,11 @@ export class MerkleTree extends Base {
         ids.push((idx / 2) | 0)
         return ids
       }, [])
+    }
+
+    const leafValues = leaves.map(i => this.leaves[i]);
+    if (!this.verifyMultiProofWithFlags(this.getRoot(), leafValues, proofs, flags)) {
+      throw new Error('cannot generate multiProof flags for parameters')
     }
 
     return flags

--- a/test/MerkleTree.test.js
+++ b/test/MerkleTree.test.js
@@ -919,8 +919,8 @@ test('sha256 getMultiProof', t => {
   ])
 })
 
-test.skip('sha256 getProofFlag with indices', t => {
-  t.plan(2)
+test('sha256 getProofFlag with indices', t => {
+  t.plan(3)
 
   const leaves = ['a', 'b', 'c', 'd'].map(sha256)
   const tree = new MerkleTree(leaves, sha256, { sortPairs: true })
@@ -928,15 +928,17 @@ test.skip('sha256 getProofFlag with indices', t => {
   t.equal(root, '0x4c6aae040ffada3d02598207b8485fcbe161c03f4cb3f660e4d341e7496ff3b2')
 
   const treeFlat = tree.getLayersFlat()
-  const proofIndices = [1, 2]
-  const proof = tree.getMultiProof(treeFlat, proofIndices)
-
+  const proofIndices = [2, 1]
+  const proof = tree.getMultiProof(proofIndices)
   const proofFlags = tree.getProofFlags(proofIndices, proof)
   t.deepEqual(proofFlags, [
     false,
     false,
     true
   ])
+  t.ok(
+    tree.verifyMultiProofWithFlags(root, proofIndices.map(i => leaves[i]), proof, proofFlags)
+  )
 })
 
 test('sha256 getMultiProof - statusim', t => {
@@ -1187,7 +1189,7 @@ test('complete option with incompatible options', t => {
 test('bad multiproof', t => {
   t.plan(1);
   const leaves = 'abcdefghi'.split('').map(keccak256).sort(Buffer.compare);
-  const merkleTree = new MerkleTree(leaves, keccak256, { sort: true });
+  const merkleTree = new MerkleTree(leaves, keccak256, { complete: true });
   const reqLeaves = leaves;
   const root = merkleTree.getHexRoot();
   const proof = merkleTree.getMultiProof(reqLeaves);

--- a/test/MerkleTree.test.js
+++ b/test/MerkleTree.test.js
@@ -1158,3 +1158,28 @@ test('ethereum-cryptography/keccak256', t => {
   const tree2 = new MerkleTree(leaves, ethCryptoKeccak256, { hashLeaves: true })
   t.equal(tree2.getHexRoot(), expectedRoot)
 })
+
+test('keccak256 with complete option', t => {
+  t.plan(1)
+
+  const leaves = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'].map(v => keccak256(Buffer.from(v)))
+  const tree = new MerkleTree(leaves, keccak256, { complete: true })
+
+  const root = '581ddb9a48c5ec60fd5a0023d4673e2b33c256f8886342bef35a8eebeda51b44'
+
+  t.equal(tree.getRoot().toString('hex'), root)
+})
+
+test('complete option with incompatible options', t => {
+  t.plan(2)
+
+  const leaves = ['a', 'b', 'c'].map(v => keccak256(Buffer.from(v)))
+  t.throws(
+    () => new MerkleTree(leaves, keccak256, { complete: true, isBitcoinTree: true }),
+    { message: 'option "complete" is incompatible with "isBitcoinTree"' },
+  )
+  t.throws(
+    () => new MerkleTree(leaves, keccak256, { complete: true, duplicateOdd: true }),
+    { message: 'option "complete" is incompatible with "duplicateOdd"' },
+  )
+})

--- a/test/MerkleTree.test.js
+++ b/test/MerkleTree.test.js
@@ -1185,16 +1185,3 @@ test('complete option with incompatible options', t => {
     /option "complete" is incompatible with "duplicateOdd"/,
   )
 })
-
-test('bad multiproof', t => {
-  t.plan(1);
-  const leaves = 'abcdefghi'.split('').map(keccak256).sort(Buffer.compare);
-  const merkleTree = new MerkleTree(leaves, keccak256, { complete: true });
-  const reqLeaves = leaves;
-  const root = merkleTree.getHexRoot();
-  const proof = merkleTree.getMultiProof(reqLeaves);
-  t.throws(
-    () => merkleTree.getProofFlags(reqLeaves, proof),
-    /cannot generate multiProof flags for parameters/,
-  );
-});

--- a/test/MerkleTree.test.js
+++ b/test/MerkleTree.test.js
@@ -919,7 +919,7 @@ test('sha256 getMultiProof', t => {
   ])
 })
 
-test('sha256 getProofFlag with indices', t => {
+test.skip('sha256 getProofFlag with indices', t => {
   t.plan(2)
 
   const leaves = ['a', 'b', 'c', 'd'].map(sha256)
@@ -1183,3 +1183,15 @@ test('complete option with incompatible options', t => {
     { message: 'option "complete" is incompatible with "duplicateOdd"' },
   )
 })
+test('bad multiproof', t => {
+  t.plan(1);
+  const leaves = 'abcdefghi'.split('').map(keccak256).sort(Buffer.compare);
+  const merkleTree = new MerkleTree(leaves, keccak256, { sort: true });
+  const reqLeaves = leaves;
+  const root = merkleTree.getHexRoot();
+  const proof = merkleTree.getMultiProof(reqLeaves);
+  t.throws(
+    () => merkleTree.getProofFlags(reqLeaves, proof),
+    /cannot generate multiProof flags for parameters/,
+  );
+});

--- a/test/MerkleTree.test.js
+++ b/test/MerkleTree.test.js
@@ -1176,13 +1176,14 @@ test('complete option with incompatible options', t => {
   const leaves = ['a', 'b', 'c'].map(v => keccak256(Buffer.from(v)))
   t.throws(
     () => new MerkleTree(leaves, keccak256, { complete: true, isBitcoinTree: true }),
-    { message: 'option "complete" is incompatible with "isBitcoinTree"' },
+    /option "complete" is incompatible with "isBitcoinTree"/,
   )
   t.throws(
     () => new MerkleTree(leaves, keccak256, { complete: true, duplicateOdd: true }),
-    { message: 'option "complete" is incompatible with "duplicateOdd"' },
+    /option "complete" is incompatible with "duplicateOdd"/,
   )
 })
+
 test('bad multiproof', t => {
   t.plan(1);
   const leaves = 'abcdefghi'.split('').map(keccak256).sort(Buffer.compare);


### PR DESCRIPTION
This library has issues with multiproofs. For numbers of leaves that are not powers of 2, the trees are shaped in a way that does not admit multiproofs for some subsets of leaves. **The main change included in this PR is a new option `complete: boolean`.** If true, this forces the shape of the tree to be that of a [complete tree](https://xlinux.nist.gov/dads/HTML/completeBinaryTree.html), which we know admits multiproofs for all subsets of leaves.

The `complete` option is made incompatible with other variants of tree generation procedures.

A warning is printed on `getMultiProof` if the tree is not complete. The intention is that this warning would be seen early during testing of a project that uses multiproofs, so that the developer learns they have to generate the tree as a complete one.

An additional recommendation we make for good use of multiproofs is to sort the tree leaves so `sortLeaves` is also recommended in the docs.

Even with these changes the library still seems to struggle with some multiproofs as seen in https://github.com/merkletreejs/merkletreejs/issues/63, which this PR doesn't fix. But the `complete` option is a necessary first step so that the generated trees have a chance of working with multiproofs. A new library will be released that can properly handle all of this.