### PR TITLE
make fillDefaultHash more efficient

### DIFF
--- a/src/MerkleTree.ts
+++ b/src/MerkleTree.ts
@@ -143,10 +143,8 @@ export class MerkleTree extends Base {
     }
 
     if (this.fillDefaultHash) {
-      for (let i = 0; i < Math.pow(2, Math.ceil(Math.log2(this.leaves.length))); i++) {
-        if (i >= this.leaves.length) {
-          this.leaves.push(this.bufferify(this.fillDefaultHash(i, this.hashFn)))
-        }
+      for (let i = this.leaves.length; i < Math.pow(2, Math.ceil(Math.log2(this.leaves.length))); i++) {
+        this.leaves.push(this.bufferify(this.fillDefaultHash(i, this.hashFn)))
       }
     }
 


### PR DESCRIPTION
Minor optimization, but fillDefaultHash currently loops everytime from 0 to this.leaves.length - 1 which is completely unnecessary and is very time inefficient.

This fix will help the efficiency of Merkle Tree creation, especially with large Merkle trees.