### PR TITLE
🔁 Bump `crypto-js` to Version `4.2.0`

### DIFF
--- a/docs/classes/_src_base_.base.md
+++ b/docs/classes/_src_base_.base.md
@@ -8,11 +8,11 @@
 
   ↳ [IncrementalMerkleTree](_src_incrementalmerkletree_.incrementalmerkletree.md)
 
+  ↳ [MerkleTree](_src_merkletree_.merkletree.md)
+
   ↳ [MerkleMountainRange](_src_merklemountainrange_.merklemountainrange.md)
 
   ↳ [MerkleSumTree](_src_merklesumtree_.merklesumtree.md)
-
-  ↳ [MerkleTree](_src_merkletree_.merkletree.md)
 
 ## Index
 

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "dependencies": {
     "bignumber.js": "^9.0.1",
     "buffer-reverse": "^1.0.1",
-    "crypto-js": "^3.1.9-1",
+    "crypto-js": "^4.2.0",
     "treeify": "^1.1.0",
     "web3-utils": "^1.3.4"
   },


### PR DESCRIPTION
I just got the following security alert in a repository, where I use `merkletreejs`:

![image](https://github.com/merkletreejs/merkletreejs/assets/25297591/70052c45-d398-46f8-b545-a2c3b4c8d791)
![image](https://github.com/merkletreejs/merkletreejs/assets/25297591/fec743fc-97e4-4c33-be57-5444d9efa480)
![image](https://github.com/merkletreejs/merkletreejs/assets/25297591/b7687121-4466-46f9-b36b-1aeb8a657752)

Therefore, I bumped the version to the latest version `4.2.0`. The tests pass as I have tested it locally.